### PR TITLE
Add ToC - Theory of constrains

### DIFF
--- a/content/br/posts/toc-theory-of-constraints.md
+++ b/content/br/posts/toc-theory-of-constraints.md
@@ -4,9 +4,9 @@ date = 2024-11-11T18:19:03-03:00
 draft = false
 +++
 
-No fim do ano passado, minha equipe começou o seu projeto mais importante até então e acabei assumindo a liderança na organização do projeto, coordenando as reuniões, o processo de entrega e etc. Durante os primeiros meses, o projeto foi andando bem, tomamos algumas decisões difíceis, provamos alguns conceitos, e iniciamos o rollout da primeira fase.
+No fim do ano passado, minha equipe começou o seu projeto mais importante até então e acabei assumindo a liderança na organização do projeto, coordenando as reuniões, o processo de entrega e etc. Durante os primeiros meses, o projeto foi andando bem, tomamos algumas decisões difíceis, provamos alguns conceitos e iniciamos o rollout da primeira fase.
 
-Contudo, eu sentia que estava atrasando o time em alguns aspects e que estava sendo um gargalo no processo como um todo. Em um 1x1 com o head da área, contei a ele sobre essa frustação e a resposta que recebi foi essa: 
+Contudo, eu sentia que estava atrasando o time em alguns aspectos e que estava sendo um gargalo no processo como um todo. Em um 1x1 com o head da área, contei a ele sobre essa frustação e a resposta que recebi foi essa:
 
 > Sim, você é um gargalo na equipe hoje, mas isso não é necessáriamente ruim.
 
@@ -47,11 +47,13 @@ Como citado anteriormente, você pode até mesmo colocar restrições forçadas 
 
 ## Conclusão
 
-Apesar do livro ser um romance e se passar numa fábrica, é possível traçar diversos paralelos com o que passamos no dia a dia de uma equipe de desenvolvimento de software. É importante perceber que nosso trabalho e nosso produto faz parte de uma cadeia maior, de um sistema, e que entender esse sistema e as restrições deles nos ajudam a manter um fluxo constante e de qualidade nas nossas entregas. Antes de tomar decisões precipitadas de otimização, valide as hipóteses! Tenha certeza de que de fato você está sendo produtivo e que está aumentando a performance de um gargalo. Alguns aprendizados que tirei lendo o livro são:
+Apesar do livro ser um romance e se passar numa fábrica, é possível traçar diversos paralelos com o que passamos no dia a dia de uma equipe de desenvolvimento de software. É importante perceber que nosso trabalho e nosso produto faz parte de uma cadeia maior, de um sistema, e que entender esse sistema e as restrições deles nos ajudam a manter um fluxo constante e de qualidade nas nossas entregas. Antes de tomar decisões precipitadas de otimização, valide as hipóteses! Tenha certeza de que de fato você está sendo produtivo e que está aumentando a performance de um gargalo.
+
+Alguns aprendizados que tirei lendo o livro são:
 - Produtividade não é o mesmo que ocupação. Você só é produtivo, se seu trabalho está te levando mais perto das suas metas. Ou seja, se você está trabalhando em algo que não vai mexer o ponteiro das metas, talvez isso não seja importante.
 - Os gargalos são o ponto mais importante do processo. Para aumentar a eficiência geral, você precisa aumentar as eficiências dos gargalos.
 - Qualquer melhoria que não seja num gargalo, é uma otimização prematura que não aumenta a eficiencia do sistema. Ter ótimos locais, não ajuda a ter um sistema ótimo.
 - Para identificar seus gargalos, aplique o método cientifico. Sugira uma hipótese, baseada em dados ou até mesmo em conhecimento empírico. Dada a hipótese, se ela for verdade algo deve acontecer. Se não acontecer, ela é descartada e uma nova idéia é validada.
 - A melhoria é sempre continua, quando surgirem novos gargalos, aplique o processo sistematico novamente. E sempre vão existir novas restrições e novos pontos de melhoria.
 
-Por fim, essa é a teoria das restrições e quem gostou eu recomendo fortemente ler o livro! 
+Por fim, aprendi mais sobre o meu papel na equipe e no projeto e entendi como posso moldar a minha participação para reduzir o impacto de ser um garlos. Essa então é a teoria das restrições e quem gostou eu recomendo fortemente ler o livro!

--- a/content/br/posts/toc-theory-of-constraints.md
+++ b/content/br/posts/toc-theory-of-constraints.md
@@ -1,0 +1,57 @@
++++
+title = 'A teoria das restrições'
+date = 2024-11-11T18:19:03-03:00
+draft = false
++++
+
+No fim do ano passado, minha equipe começou o seu projeto mais importante até então e acabei assumindo a liderança na organização do projeto, coordenando as reuniões, o processo de entrega e etc. Durante os primeiros meses, o projeto foi andando bem, tomamos algumas decisões difíceis, provamos alguns conceitos, e iniciamos o rollout da primeira fase.
+
+Contudo, eu sentia que estava atrasando o time em alguns aspects e que estava sendo um gargalo no processo como um todo. Em um 1x1 com o head da área, contei a ele sobre essa frustação e a resposta que recebi foi essa: 
+
+> Sim, você é um gargalo na equipe hoje, mas isso não é necessáriamente ruim.
+
+Tentei argumentar, pois não entendia como um gargalo não seria ruim e ele comecou a me falar da teoria das restrições. No fim de nosso papo, ele me indicou a leitura de um livro chamado The Goal: A Process of Ongoing Improvement, do Eliyahu M. Goldratt e quero compartilhar o que aprendi aqui.
+
+## Métricas
+
+Para entender a teoria das restrições, precisamos entender antes de mais nada qual é o objetivo de qualquer empresa. Pode-se argumentar que as empresas tentam mudar o mundo, prover serviços melhores, mas no fim o foco sempre é o mesmo: fazer dinheiro. E se esse é o objetivo final de cada empresa, todo nosso foco, métricas e etc devem mirar pra este objetivo. 
+
+Contudo, como fazer dinheiro é um objetivo bem genérico, o autor define três termos para focarmos, sendo eles:
+- produção: a forma que a empresa gera dinheiro;
+- inventário: o dinheiro investido e que eventualmente vai retornar mais dinheiro;
+- despesa operacional: o dinheiro gasto em transformar o inventário em dinheiro;
+
+Nesse sentido, precisamos sempre visar aumentar a produção, reduzindo o inventário e as despesas operacionais e as metricas mais importantes devem se basear em analisar o impacto nesses pontos.
+
+Extrapolando para o mundo de software, temos:
+- produção: funcionalidades, produtos e tudo que possa ser vendido a um cliente;
+- inventário: servidores, cloud, e tudo que vai ser parte do software na entrega final;
+- despesas operacionais: programadores, P.Os, heads;
+
+Ou seja, precisamos entregar mais funcionalidades e produtos, reduzindo ou mantendo a quantidade de hardware necessária e a quantidade de funcionários.
+
+## Conceito
+
+Agora que já temos um objetivo claro, podemos finalmente falar sobre o que é a Teoria das Restrições (ToC - Theory of Constraints, em inglês). Ela é um processo de melhoria continua que visa encontrar os gargalos, ou restrições, de um sistema e trabalhar ao redor deles. É importante frisar que não existe um sistema sem gargalos, eles sempre vão existir e sempre vão regular o fluxo de entregas do seu sistema.
+
+Voltamos então ao ponto inicial do que me fez ler o livro, gargalos não são fundamentalmente ruins! Eles apenas existem e até mesmo são necessários. Um semáforo é um ótimo exemplo de gargalos que não são ruins, já que eles limitam a quantidade de carros em algumas vias e organizam o fluxo. No processo de desenvolvimento de software, temos alguns gargalos que também são considerados essenciais: code review e testes. Ambos diminuem a velocidade de entrega, mas visam garantir uma melhor qualidade final.
+
+Contudo, vale a pena mencionar que a única capacidade que importa é a dos gargalos, já que a velocidade do sistema nunca vai ser maior do que a velocidade dele. A teoria das restrições visa então entender quais os gargalos do seu sistema e como você pode contorna-los, ou até mesmo os remover, através de um processo sistemático:
+1. Identificar as restrições ou os gargalos do sistema;
+2. Decidir como tirar o máximo proveito desses gargalos;
+3. Evite produzir mais do que o gargalo pode suportar, ou seja, contorne o gargalo;
+4. Eleve os gargalos do sistema ou expanda a capacidade com mais investimentos;
+5. Se, o gargalo tiver sido eliminado, volte à etapa 1 e comece novamente. Se o processo apresentar melhorias, o gargalo podem mudar de lugar e você deve estar preparado para outros gargalos surgirem.
+
+Como citado anteriormente, você pode até mesmo colocar restrições forçadas no seu sistema, para garantir um fluxo continuo de entrega, no caso do desenvolvimento de software, code reviews, por exemplo. Mas elas não são as únicas! Posso listar por exemplo, banco de dados, rate-limit em APIs, capacidade do time, pair programming e uma infinidade de outros possíveis gargalos que enfrentamos ao construir um software.
+
+## Conclusão
+
+Apesar do livro ser um romance e se passar numa fábrica, é possível traçar diversos paralelos com o que passamos no dia a dia de uma equipe de desenvolvimento de software. É importante perceber que nosso trabalho e nosso produto faz parte de uma cadeia maior, de um sistema, e que entender esse sistema e as restrições deles nos ajudam a manter um fluxo constante e de qualidade nas nossas entregas. Antes de tomar decisões precipitadas de otimização, valide as hipóteses! Tenha certeza de que de fato você está sendo produtivo e que está aumentando a performance de um gargalo. Alguns aprendizados que tirei lendo o livro são:
+- Produtividade não é o mesmo que ocupação. Você só é produtivo, se seu trabalho está te levando mais perto das suas metas. Ou seja, se você está trabalhando em algo que não vai mexer o ponteiro das metas, talvez isso não seja importante.
+- Os gargalos são o ponto mais importante do processo. Para aumentar a eficiência geral, você precisa aumentar as eficiências dos gargalos.
+- Qualquer melhoria que não seja num gargalo, é uma otimização prematura que não aumenta a eficiencia do sistema. Ter ótimos locais, não ajuda a ter um sistema ótimo.
+- Para identificar seus gargalos, aplique o método cientifico. Sugira uma hipótese, baseada em dados ou até mesmo em conhecimento empírico. Dada a hipótese, se ela for verdade algo deve acontecer. Se não acontecer, ela é descartada e uma nova idéia é validada.
+- A melhoria é sempre continua, quando surgirem novos gargalos, aplique o processo sistematico novamente. E sempre vão existir novas restrições e novos pontos de melhoria.
+
+Por fim, essa é a teoria das restrições e quem gostou eu recomendo fortemente ler o livro! 

--- a/content/en/posts/toc-theory-of-constraints.md
+++ b/content/en/posts/toc-theory-of-constraints.md
@@ -1,0 +1,5 @@
++++
+title = 'The theory of constraints'
+date = 2024-11-11T18:19:03-03:00
+draft = false
++++

--- a/content/en/posts/toc-theory-of-constraints.md
+++ b/content/en/posts/toc-theory-of-constraints.md
@@ -3,3 +3,57 @@ title = 'The theory of constraints'
 date = 2024-11-11T18:19:03-03:00
 draft = false
 +++
+
+At the end of 2023, my squad started its most important project. I assumed the project leadership role, organizing the project, coordinating the meetings, the release process, etc. At the first months, the project went well, as we took some hard decisions, proved a couple of concepts, and started the rollout for the first phase.
+
+However, I always felt that I was holding the team back and being a bottleneck in the whole team. At a 1x1 with the head of the area, I told him about my frustration and got this answer back:
+
+> Yes, you are being a bottleneck for the team, but that isn't necessarily bad.
+
+I tried to argue with him because I couldn't understand how being a bottleneck wasn't bad, and then he introduced me the theory of constraints. In the end, he recommended a book by Eliyahu M. Goldratt called The Goal: A Process of Ongoing Improvement. Hence, I want to share what I took from it here.
+
+## Metrics
+
+Before we understand the theory of constraints, we need to know what are the company main goal. We can argue that companies try to improve the world, or they provide better services but that isn't their main goal. Their focus is earning money, and if this is the final goal for every company, all our focus should be on achieving this objective.
+
+Because making money is a generic goal, the author gives us three goals to focus on. They are:
+production: how the company makes money;
+inventory: the money the company has invested to make more money;
+operational expense: the money spent on turning inventory into production;
+
+In that sense, we should aim to increase the production, while reducing inventory and operational expenses. Also, all metrics must have an impact on the company's goals.
+
+Extrapolating to the world of software engineering, we have:
+- production: features, products, and everything that can be sold to a client;
+- inventory: servers, cloud, hardware, and everything that is part of the product;
+- operational expenses: programmers, P.Os, heads;
+
+So, we need to deliver more features and products while reducing the amount of hardware and people.
+
+## Concept
+
+Now that we have a clear goal, we can talk about the ToC. In short, it is a continuous improvement process that aims to find the system's constraints and work around them. It is important to define that a system without restrictions doesn't exist. They will always be there, and most importantly, they regulate the delivery flow.
+
+Let's move back to the initial point that made me read the book, constraints aren't essentially good or bad! Restrictions exist, and sometimes, they are necessary. A great example is a semaphore since they regulate the flow of cars and the speed in certain streets. Again, they aren't bad, they simply exist. During the software development process, we also have some constraints that are considered essential, like code review and writing tests. Both slow us down, but they ensure a higher quality.
+
+However, it is worth mentioning that the only capacity that matters is the constraints because the system will never be able to deliver more than what the constraint can. The ToC aims to understand which constraints you have and how you can work around, or even remove, them by following a systematic approach.
+1. Identify the constraint or constraints of your system;
+2. Explore how you can work with them;
+3. Avoid producing more than the constraint can handle, or in other words, work around the constraint;
+4. Elevate the constraints of your system or expand its capacity with new investments;
+5. If the constraint has been eliminated, move back to phase 1 and start over. If the process shows improvements, be prepared for the constraint to move to another point or if new constraints appear;
+
+As I said, you can also add constraints to your system to ensure a continuous delivery flow. For example, in software engineering, you can start doing code reviews. But they are not the only constraints! I can also list databases, rate-limiting on APIs, team capacity, pair programming, and other infinity of constraints that we can deal with while building software.
+
+## Conclusion
+
+Despite the book being a romance and happening in an industry, it is possible to draw a parallel to what we live daily in a software development team. It is important to note that our job is part of a larger system, and you should understand it and its restrictions to build an effective and constant delivery flow. Before you make any optimization, be sure that you validate all hypotheses. Make sure that you are being productive and if you are, in fact, increasing the performance of a bottleneck.
+
+Summarizing what I learn from the book:
+Productivity and occupation aren't synonymous. Work is only productive if it brings you closer to your goals. If not, maybe you're working on something that isn't so important;
+Bottlenecks are the system's main part! To increase the overall efficiency, you must increase the efficiency on the constraints;
+Each improvement at a non-bottleneck is a premature optimization that doesn't improve the overall efficiency. Having local optimus doesn't bring you closer to an optimized system;
+To identify your constraints, apply the scientific method. Suggest a hypothesis, and if it turns true, something should happen. If not, you may discard it and validate a new idea;
+The optimization is always continuous. When new bottlenecks appear, apply the systematic approach again. It will always emerge new restrictions and new improvement opportunities;
+
+Lastly, I learned more about my role at the squad and the project. Now, I have a better understanding on how I work and how I can reduce the impact of being a bottleneck. That is the Theory of Constraints, and for those who enjoyed it, I recommend reading the book!


### PR DESCRIPTION
This pull request adds new content to the blog, specifically a detailed post on the Theory of Constraints in both Portuguese and English. The most important changes include the addition of the post content and metadata in both languages.

New content additions:

* [`content/br/posts/toc-theory-of-constraints.md`](diffhunk://#diff-0d872be8a130c2b1ba0d2c6d62e43093d32e1ed759f52b9c926bb0488347aad7R1-R57): Added a comprehensive post discussing the Theory of Constraints, including its metrics, concepts, and application to software development.
* [`content/en/posts/toc-theory-of-constraints.md`](diffhunk://#diff-4428e7ec900bb677dee5e3c216ffe9a8523512ae7013403ee544d449d1df6d7cR1-R5): Added the title, date, and draft status for the English version of the Theory of Constraints post.