### PR TITLE
Add go-prometheus

### DIFF
--- a/content/br/posts/go-prometheus.md
+++ b/content/br/posts/go-prometheus.md
@@ -2,6 +2,7 @@
 title = 'Métricas com Go e Prometheus'
 date = 2024-12-27T19:07:46-03:00
 draft = false
+tags = ["go", "monitoring", "metrics", "prometheus"]
 +++
 
 No mundo do desenvolvimento, é necessário saber como a aplicação que estamos trabalhando está se comportando e a maneira mais conhecida de realizarmos isso é por meio de métricas.  Elas podem ser de diversos tipos, como, por exemplo, de desempenho, de produto ou de saúde. Atualmente, o [Prometheus](https://www.cncf.io/projects/prometheus/) é amplamente utilizado pelo mercado a fim de coletar essas métricas.
@@ -83,7 +84,7 @@ scrape_configs:
     - 'myapp:8080'
 ```
 
-Se quiser verificar se tudo está funcionando, é só acessar `http://localhost:9090` e ver se deu certo a configuração. Contudo, muitas vezes as métricas padrões não são suficientes para representar o comportamento da nossa aplicação e é necessário definir métricas customizadas. Ao utilizar a biblioteca padrão do Prometheus para Go, essa tarefa se torna trivial, simples como o exemplo abaixo:
+Se quiser verificar se tudo está funcionando, é só acessar `http://localhost:9090` e ver se deu certo a configuração. Contudo, muitas vezes as métricas padrões não são suficientes para representar o comportamento da nossa aplicação e é necessário definir métricas customizadas. Ao utilizar a biblioteca padrão do Prometheus para Go, essa tarefa se torna trivial e simples, como o exemplo abaixo:
 
 ```golang
 successRate := promauto.NewCounter(prometheus.CounterOpts{
@@ -94,7 +95,7 @@ successRate := promauto.NewCounter(prometheus.CounterOpts{
 successRate.Inc()
 ```
 
-Desta forma, uma nova métrica será retornada ao acessar o endpoint `/metrics`. Contudo, nem sempre é possível ter um servidor web para ter as métricas expostas dessa forma. A partir dessa premissa, foi desenvolvido o [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/). Ele funciona da seguinte forma: você envia suas métricas por chamadas HTTP e ele armazena e expõe o endpoint `/metrics` para a coleta do Prometheus. Contudo, nem sempre é uma boa ideia utilizar esta estratégia, pois, segundo a própria documentação oficial:
+Desta forma, uma nova métrica será retornada ao acessar o endpoint `/metrics`. Porém, nem sempre é possível ter um servidor web para ter as métricas expostas dessa forma. A partir dessa premissa, foi desenvolvido o [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/). Ele funciona da seguinte forma: você envia suas métricas por chamadas HTTP e ele armazena e expõe o endpoint `/metrics` para a coleta do Prometheus. Todavia, nem sempre é uma boa ideia utilizar esta estratégia, pois, segundo a própria documentação oficial:
 - Quando se monitora múltiplas instâncias por meio de um único Pushgateway, ele se torna um ponto único de falha e um potencial gargalo.
 - Você perde o monitoramento automático da saúde da sua aplicação, gerada em cada varredura.
 - O Pushgateway nunca esquece nenhum dado que foi enviado para ele e vai sempre os expor para o Prometheus, exceto caso seja manualmente deletado.

--- a/content/br/posts/go-prometheus.md
+++ b/content/br/posts/go-prometheus.md
@@ -1,0 +1,158 @@
++++
+title = 'Métricas com Go e Prometheus'
+date = 2024-12-27T19:07:46-03:00
+draft = false
++++
+
+No mundo do desenvolvimento, é necessário saber como a aplicação que estamos trabalhando está se comportando e a maneira mais conhecida de realizarmos isso é por meio de métricas.  Elas podem ser de diversos tipos, como, por exemplo, de desempenho, de produto ou de saúde. Atualmente, o [Prometheus](https://www.cncf.io/projects/prometheus/) é amplamente utilizado pelo mercado a fim de coletar essas métricas.
+
+Ele é um serviço open-source mantido pela [CNCF](https://www.cncf.io/), a Cloud Native Computing Foundation. Ele funciona da seguinte maneira: um endpoint é exposto na aplicação. Esse endpoint retorna um texto no formato esperado, e o Prometheus acessa esse endpoint de tempos em tempos coletando as informações dali. 
+
+```
+# HELP failure_rate The total number of failed events
+# TYPE failure_rate counter
+failure_rate 3280
+```
+
+O formato é bem simples, para cada métrica, você vai ter pelo menos três entradas:
+- O #HELP mostra a descrição da métrica. 
+- O #TYPE define o tipo da métrica.
+- A terceira linha mostra o valor da métrica.
+
+Em aplicações escritas com Go, temos uma biblioteca que facilita ainda mais a exposição dessas métricas. Ela implementa um handler que expõe por padrão as principais métricas relacionadas ao software, como, por exemplo, goroutines, memória, heap, etc. O exemplo abaixo demonstra melhor como se usa:
+
+```golang
+package main
+
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func main() {
+  fmt.Println("Monitoring service...")
+  http.Handle("/metrics", promhttp.Handler())
+  http.ListenAndServe(":8080", nil)
+}
+```
+
+Pode-se notar que com poucas linhas temos o endpoint de métricas e um servidor web funcionando! Agora, como configurar um Prometheus para coletá-las? O primeiro passo é subir ambas as aplicações, para isso o melhor é utilizar o `docker compose`. 
+
+```yaml
+services:
+  myapp:
+    image: myapp
+    build: .
+    container_name: myapp
+    ports:
+      - 8080:8080
+    restart: unless-stopped
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+volumes:
+  prom_data:
+```
+
+No arquivo compose, é definida que a aplicação vai escutar na porta `8080` e o Prometheus na porta `9090`. Ele também espera um arquivo de configuração. Este arquivo define onde e com qual frequência ele deve fazer a varredura.
+
+```yaml
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: myapp
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - 'myapp:8080'
+```
+
+Se quiser verificar se tudo está funcionando, é só acessar `http://localhost:9090` e ver se deu certo a configuração. Contudo, muitas vezes as métricas padrões não são suficientes para representar o comportamento da nossa aplicação e é necessário definir métricas customizadas. Ao utilizar a biblioteca padrão do Prometheus para Go, essa tarefa se torna trivial, simples como o exemplo abaixo:
+
+```golang
+successRate := promauto.NewCounter(prometheus.CounterOpts{
+  Name: "success_rate",
+  Help: "The total number of succeded events",
+})
+
+successRate.Inc()
+```
+
+Desta forma, uma nova métrica será retornada ao acessar o endpoint `/metrics`. Contudo, nem sempre é possível ter um servidor web para ter as métricas expostas dessa forma. A partir dessa premissa, foi desenvolvido o [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/). Ele funciona da seguinte forma: você envia suas métricas por chamadas HTTP e ele armazena e expõe o endpoint `/metrics` para a coleta do Prometheus. Contudo, nem sempre é uma boa ideia utilizar esta estratégia, pois, segundo a própria documentação oficial:
+- Quando se monitora múltiplas instâncias por meio de um único Pushgateway, ele se torna um ponto único de falha e um potencial gargalo.
+- Você perde o monitoramento automático da saúde da sua aplicação, gerada em cada varredura.
+- O Pushgateway nunca esquece nenhum dado que foi enviado para ele e vai sempre os expor para o Prometheus, exceto caso seja manualmente deletado.
+
+Para mais informações, recomendo a leitura dessa [documentação](https://prometheus.io/docs/practices/pushing/). Mas, como existem casos de uso, vamos ver como podemos usar a biblioteca do Prometheus para fazer um Push. O exemplo abaixo demonstra que muda muito pouco do exemplo anterior. Só adicionamos a instrução referente ao Push e para onde ele deve ser realizado.
+
+```golang
+successRate := promauto.NewCounter(prometheus.CounterOpts{
+  Name: "success_rate_pg",
+  Help: "The total number of succeded events",
+})
+
+p.successRate.Inc()
+
+err := push.New("http://pushgateway:9091", "pg").
+  Collector(p.successRate).
+  Grouping("myapp", "success_rate_pg").
+  Push()
+
+if err != nil {
+  fmt.Println("Could not push completion time to Pushgateway:", err)
+}
+```
+
+Também é necessário configurar o compose para iniciar o Pushgateway.
+
+```yaml
+services:
+  # ... myapp and prometheus already exposed
+  pushgateway:
+    image: prom/pushgateway
+    container_name: pushgateway
+    restart: unless-stopped
+    expose:
+      - 9091
+    ports:
+      - "9091:9091"
+```
+
+E por fim, vamos dizer ao Prometheus que ele deve varrer o Pushgateway também.
+
+```yaml
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: pushgateway
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - 'pushgateway:9091'
+```
+
+Vale a pena mencionar que, para o exemplo, eu utilizei somente o tipo de métrica Counter, ou em português Contador. Contudo, existem diversos outros tipos que podem ser encontrados [aqui](https://prometheus.io/docs/concepts/metric_types/)! Para mais exemplos utilizando o Prometheus com Go, você pode checar os [exemplos oficiais](https://github.com/prometheus/client_golang/tree/main/examples) da biblioteca ou a [PoC](https://github.com/mfbmina/poc-prometheus-exporter) onde implemento um simulador de monitoramento sintético e gero métricas através do endpoint e do Pushgateway.
+
+Se você gostou do post, me diz: quais métricas você geralmente monitora na sua aplicação? Elas são métricas padrões ou customizadas?

--- a/content/en/posts/go-prometheus.md
+++ b/content/en/posts/go-prometheus.md
@@ -1,0 +1,159 @@
++++
+title = 'Metrics with Go and Prometheus'
+date = 2024-12-27T19:07:46-03:00
+draft = false
+tags = ["go", "monitoring", "metrics", "prometheus"]
++++
+
+At the developing world, it is necessary to know how the application that you're working on is behaving, and the most known way of doing that is by metrics. They can be of several types, such as performance, product, or health. Nowadays, [Prometheus](https://www.cncf.io/projects/prometheus/) is the market way for collecting metrics.
+
+It is an open-source service maintained by [CNCF](https://www.cncf.io/), the Cloud Native Computing Foundation. It works like the following: an endpoint is exposed, and it responds with a desired body format. Then Prometheus calls this endpoint time to time, collecting all the information from there. 
+
+```
+# HELP failure_rate The total number of failed events
+# TYPE failure_rate counter
+failure_rate 3280
+```
+
+This format is pretty simple. For each metric, there are three entries:
+- #HELP shows its description.
+- #TYPE defines its type.
+- The third value has its value.
+
+In Go apps, there is a lib that facilitates even more the metrics exposition. It implements a handler and this handler exposes by default the main metrics related to the software, like memory, heap or even information about goroutines. The example below describes better how to use it:
+
+```golang
+package main
+
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func main() {
+  fmt.Println("Monitoring service...")
+  http.Handle("/metrics", promhttp.Handler())
+  http.ListenAndServe(":8080", nil)
+}
+```
+
+It is noticeable that with a few lines we have a running web server with an endpoint for metrics! Now, how to configure Prometheus to collect them? The first step is to run both apps, and for that we can use `docker compose`.
+
+```yaml
+services:
+  myapp:
+    image: myapp
+    build: .
+    container_name: myapp
+    ports:
+      - 8080:8080
+    restart: unless-stopped
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+volumes:
+  prom_data:
+```
+
+At compose file, it is defined that the app will listen at `8080` port and Prometheus will listen`9090`. It also expects for a configuration file that defines where and how frequently it should scrap.
+
+```yaml
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: myapp
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - 'myapp:8080'
+```
+
+If you want to ensure that everything is fine, you can access `http://localhost:9090` and check if the configuration worked. However, most times the default metrics are not enough to understand how our app is behaving and then must define custom metrics. When using the Prometheus standard lib for Go, this task turns out to be simple, as shown below:
+
+```golang
+successRate := promauto.NewCounter(prometheus.CounterOpts{
+  Name: "success_rate",
+  Help: "The total number of succeded events",
+})
+
+successRate.Inc()
+```
+
+That way, a new metric will be returned when accessing the endpoint `/metrics`. But, it is not always possible to have a web server to expose metrics. From that premise, the  [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/) was developed. It works like the following: you send your metrics to it using HTTP calls, and it stores all data. Eventually a Prometheus instance will scrap its information. Anyway, it is not always a good idea to use this strategy. Quoting the official documentation:
+- When monitoring multiple instances through a single Pushgateway, the Pushgateway becomes both a single point of failure and a potential bottleneck.
+- You lose Prometheus's automatic instance health monitoring via the "up" metric (generated on every scrape).
+- The Pushgateway never forgets series pushed to it and will expose them to Prometheus forever unless those series are manually deleted via the Pushgateway's API.
+
+For more information, I recommend read this [doc](https://prometheus.io/docs/practices/pushing/). Still, how there are use cases, let's see how to use the Prometheus lib for pushing metrics. The example below demonstrates that it almost do not change from the previous example. It is just necessary to add the instruction for where the push should be made.
+
+```golang
+successRate := promauto.NewCounter(prometheus.CounterOpts{
+  Name: "success_rate_pg",
+  Help: "The total number of succeded events",
+})
+
+p.successRate.Inc()
+
+err := push.New("http://pushgateway:9091", "pg").
+  Collector(p.successRate).
+  Grouping("myapp", "success_rate_pg").
+  Push()
+
+if err != nil {
+  fmt.Println("Could not push completion time to Pushgateway:", err)
+}
+```
+
+It is also important to configure the Docker compose to start the Pushgateway.
+
+```yaml
+services:
+  # ... myapp and prometheus already exposed
+  pushgateway:
+    image: prom/pushgateway
+    container_name: pushgateway
+    restart: unless-stopped
+    expose:
+      - 9091
+    ports:
+      - "9091:9091"
+```
+
+At last, let's tell Prometheus that it should collect metrics from  Pushgateway too.
+
+```yaml
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: pushgateway
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - 'pushgateway:9091'
+```
+
+It's worth mentioning that, for the example, I only used the type counter. Therefore, there are other types that can be found [here](https://prometheus.io/docs/concepts/metric_types/)! For more examples on how to use Prometheus with Go, you can check the [official examples](https://github.com/prometheus/client_golang/tree/main/examples) or the [PoC](https://github.com/mfbmina/poc-prometheus-exporter) where I build a synthetic monitor simulator and build metrics for the default endpoint and for Pushgateway.
+
+If you liked the post, tell me: which metrics you usually monitor at your application? Are they  custom or default metrics?


### PR DESCRIPTION
This pull request introduces a new blog post titled "Métricas com Go e Prometheus" in the `content/br/posts/go-prometheus.md` file. The post provides a comprehensive guide on how to use Prometheus to collect metrics in Go applications, including setup instructions and example code snippets.

Key changes include:

* **New Blog Post**:
  - Added a new blog post with the title "Métricas com Go e Prometheus," including the date, draft status, and content.

* **Prometheus Integration**:
  - Explained the basics of Prometheus and how it collects metrics from an exposed endpoint in applications.
  - Provided a Go example to demonstrate how to expose metrics using the `promhttp` handler.
  - Included a `docker-compose` configuration to set up both the Go application and Prometheus for metrics collection.

* **Custom Metrics**:
  - Illustrated how to define and use custom metrics in Go using the Prometheus client library.

* **Pushgateway Setup**:
  - Described the use of Pushgateway for scenarios where a web server is not available to expose metrics and provided example code for pushing metrics.
  - Updated the `docker-compose` configuration to include Pushgateway and configured Prometheus to scrape metrics from